### PR TITLE
Enhancement (development): Do not require `docker-container` build driver in development

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -52,7 +52,7 @@ jobs:
       if: matrix.testenv == 'dev'
       run: |
         set -eux
-        docker compose up --build -d
+        docker compose -f docker-compose.yml -f docker-compose.build.yml up --build -d
         docker compose -f docker-compose.test.yml --profile dev up
 
     - name: Integration test (prod)

--- a/README.md
+++ b/README.md
@@ -80,9 +80,6 @@ echo '127.0.0.1 phpmyadmin.example.com' | sudo tee -a /etc/hosts
 ## Development
 
 ```sh
-# Setup docker buildx builder
-docker buildx create --name mybuilder --driver docker-container --use
-
 # 1. Start Counter-strike 1.6 server, source-udp-forwarder, HLStatsX:CE stack
 docker compose up --build
 # HLStatsX:CE web frontend available at http://localhost:8081/. Admin Panel username: admin, password 123456

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,10 +1,7 @@
-# This is a docker compose override file, for testing production builds with caching for CI environments
+# This is a docker compose override file, for development builds with caching for CI environments
 services:
   daemon:
     build:
-      dockerfile: Dockerfile.daemon
-      context: .
-      target: prod
       cache_from:
         - type=local,src=/tmp/.buildx-cache-daemon
       cache_to:
@@ -12,9 +9,6 @@ services:
 
   awards:
     build:
-      dockerfile: Dockerfile.daemon
-      context: .
-      target: prod
       cache_from:
         - type=local,src=/tmp/.buildx-cache-daemon
       cache_to:
@@ -22,9 +16,6 @@ services:
 
   web:
     build:
-      dockerfile: Dockerfile.web
-      context: .
-      target: prod
       cache_from:
         - type=local,src=/tmp/.buildx-cache-web
       cache_to:
@@ -32,9 +23,6 @@ services:
 
   heatmaps:
     build:
-      dockerfile: Dockerfile.web
-      context: .
-      target: prod
       cache_from:
         - type=local,src=/tmp/.buildx-cache-web
       cache_to:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,10 +60,6 @@ services:
       dockerfile: Dockerfile.daemon
       context: .
       target: dev
-      cache_from:
-        - type=local,src=/tmp/.buildx-cache-daemon
-      cache_to:
-        - type=local,dest=/tmp/.buildx-cache-daemon,mode=max
     ports:
       - 27500:27500/udp   # For external servers to send logs to the daemon
     networks:
@@ -86,10 +82,6 @@ services:
       dockerfile: Dockerfile.daemon
       context: .
       target: dev
-      cache_from:
-        - type=local,src=/tmp/.buildx-cache-daemon
-      cache_to:
-        - type=local,dest=/tmp/.buildx-cache-daemon,mode=max
     stop_signal: SIGKILL
     entrypoint:
       - /bin/sh
@@ -140,10 +132,6 @@ services:
       dockerfile: Dockerfile.web
       context: .
       target: dev
-      cache_from:
-        - type=local,src=/tmp/.buildx-cache-web
-      cache_to:
-        - type=local,dest=/tmp/.buildx-cache-web,mode=max
     volumes:
       - ./web:/web
       # - ./config/web/supervisor.conf:/supervisor.conf:ro
@@ -174,10 +162,6 @@ services:
       dockerfile: Dockerfile.web
       context: .
       target: dev
-      cache_from:
-        - type=local,src=/tmp/.buildx-cache-web
-      cache_to:
-        - type=local,dest=/tmp/.buildx-cache-web,mode=max
     volumes:
       - ./heatmaps:/heatmaps
       - ./web:/web


### PR DESCRIPTION
This allows for plain docker driver, and even legacy builder to work, i.e. compatible with docker-compose v1.
