### PR TITLE
Enhancement (development): Add `depends_on: db` to `daemon` to make it stop before `db`

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -61,6 +61,8 @@ services:
       - 27500:27500/udp   # For external servers to send logs to the daemon
     networks:
       - default
+    depends_on:
+      - db
     command:
       - --ip=0.0.0.0
       - --port=27500

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,8 @@ services:
       - 27500:27500/udp   # For external servers to send logs to the daemon
     networks:
       - default
+    depends_on:
+      - db
     command:
       - --ip=0.0.0.0
       - --port=27500


### PR DESCRIPTION
This ensures the daemon cleanly flushes to DB before the DB is shut down.
