### PR TITLE
Fix (ci): Don't use `cache_to` in CI builds to prevent race conditions causing docker builds to fail

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -4,26 +4,26 @@ services:
     build:
       cache_from:
         - type=local,src=/tmp/.buildx-cache-daemon
-      cache_to:
-        - type=local,dest=/tmp/.buildx-cache-daemon,mode=max
+      # cache_to:
+      #   - type=local,dest=/tmp/.buildx-cache-daemon,mode=max
 
   awards:
     build:
       cache_from:
         - type=local,src=/tmp/.buildx-cache-daemon
-      cache_to:
-        - type=local,dest=/tmp/.buildx-cache-daemon,mode=max
+      # cache_to:
+      #   - type=local,dest=/tmp/.buildx-cache-daemon,mode=max
 
   web:
     build:
       cache_from:
         - type=local,src=/tmp/.buildx-cache-web
-      cache_to:
-        - type=local,dest=/tmp/.buildx-cache-web,mode=max
+      # cache_to:
+      #   - type=local,dest=/tmp/.buildx-cache-web,mode=max
 
   heatmaps:
     build:
       cache_from:
         - type=local,src=/tmp/.buildx-cache-web
-      cache_to:
-        - type=local,dest=/tmp/.buildx-cache-web,mode=max
+      # cache_to:
+      #   - type=local,dest=/tmp/.buildx-cache-web,mode=max

--- a/docker-compose.example.build.yml
+++ b/docker-compose.example.build.yml
@@ -7,8 +7,8 @@ services:
       target: prod
       cache_from:
         - type=local,src=/tmp/.buildx-cache-daemon
-      cache_to:
-        - type=local,dest=/tmp/.buildx-cache-daemon,mode=max
+      # cache_to:
+      #   - type=local,dest=/tmp/.buildx-cache-daemon,mode=max
 
   awards:
     build:
@@ -17,8 +17,8 @@ services:
       target: prod
       cache_from:
         - type=local,src=/tmp/.buildx-cache-daemon
-      cache_to:
-        - type=local,dest=/tmp/.buildx-cache-daemon,mode=max
+      # cache_to:
+      #   - type=local,dest=/tmp/.buildx-cache-daemon,mode=max
 
   web:
     build:
@@ -27,8 +27,8 @@ services:
       target: prod
       cache_from:
         - type=local,src=/tmp/.buildx-cache-web
-      cache_to:
-        - type=local,dest=/tmp/.buildx-cache-web,mode=max
+      # cache_to:
+      #   - type=local,dest=/tmp/.buildx-cache-web,mode=max
 
   heatmaps:
     build:
@@ -37,5 +37,5 @@ services:
       target: prod
       cache_from:
         - type=local,src=/tmp/.buildx-cache-web
-      cache_to:
-        - type=local,dest=/tmp/.buildx-cache-web,mode=max
+      # cache_to:
+      #   - type=local,dest=/tmp/.buildx-cache-web,mode=max


### PR DESCRIPTION
Fixes #28
