### PR TITLE
Fix (web/updater): Add dummy update `$dbversion = 85` for 1.11.0

### DIFF
--- a/src/web/updater/85.php
+++ b/src/web/updater/85.php
@@ -1,0 +1,14 @@
+<?php
+    if ( !defined('IN_UPDATER') )
+    {
+        die('Do not access this file directly.');
+    }
+
+    $dbversion = 85;
+    $version = "1.11.0";
+
+    // Perform database schema update notification
+    print "Updating database and verion schema numbers.<br />";
+    $db->query("UPDATE hlstats_Options SET `value` = '$version' WHERE `keyname` = 'version'");
+    $db->query("UPDATE hlstats_Options SET `value` = '$dbversion' WHERE `keyname` = 'dbversion'");
+?>


### PR DESCRIPTION
Fixes bug in #41 where `updater` didn't match `install.sql` for release 1.11.0
