### PR TITLE
Fix (development): Fix xdebug path mapping

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,8 +10,8 @@
             "request": "launch",
             "port": 9000,
             "pathMappings": {
-                "/heatmaps": "${workspaceRoot}/heatmaps",
-                "/web": "${workspaceRoot}/web",
+                "/heatmaps": "${workspaceRoot}/src/heatmaps",
+                "/web": "${workspaceRoot}/src/web",
             },
             "xdebugSettings": {
                 "max_data": 10000,


### PR DESCRIPTION
This fixes xdebug behavior in vscode so that it opens the debugged files correctly. This fix should have been in #35 when the files were moved to `./src`.
