### PR TITLE
Fix: Fix Tau Cannon and Gluon Gun names in awards and weapons pages

### DIFF
--- a/src/web/updater/90.php
+++ b/src/web/updater/90.php
@@ -1,0 +1,22 @@
+<?php
+    if ( !defined('IN_UPDATER') )
+    {
+        die('Do not access this file directly.');
+    }
+
+    // $dbversion = 90;
+    // $version = "1.11.5";
+
+    // Fix `tau_cannon`
+    $db->query("UPDATE hlstats_Awards SET `name` = 'Gauss King' WHERE `code` = 'tau_cannon'");
+    $db->query("UPDATE hlstats_Weapons SET `name` = 'Tau Cannon / Rail Gun' WHERE `code` = 'tau_cannon'");
+    
+    // Fix `gluon gun`
+    $db->query("UPDATE hlstats_Awards SET `name` = 'Egon King' WHERE `code` = 'gluon gun'");
+    $db->query("UPDATE hlstats_Weapons SET `name` = 'Egon / Gluon Gun' WHERE `code` = 'gluon gun'");
+
+    // Perform database schema update notification
+    // print "Updating database and verion schema numbers.<br />";
+    // $db->query("UPDATE hlstats_Options SET `value` = '$version' WHERE `keyname` = 'version'");
+    // $db->query("UPDATE hlstats_Options SET `value` = '$dbversion' WHERE `keyname` = 'dbversion'");
+?>


### PR DESCRIPTION
Fixes #63
