### PR TITLE
Fix (web): Show spectators and HLTV as 'Spectator' team in livestats table

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,21 @@ services:
           set -eu
           exec hlds_linux -console -noipx -secure -game cstrike +map de_dust2 +maxplayers 32 +sv_lan 0 +ip 0.0.0.0 +port 27015 +rcon_password password +log on +logaddress_add 10.5.0.50 27500 +sv_visiblemaxplayers 30
 
+  # 1b. Uncomment to enable HLTV for CS1.6
+  # hltv:
+  #   image: goldsourceservers/cstrike:latest
+  #   ports:
+  #     - 27020:27020/udp
+  #   stop_signal: SIGKILL
+  #   entrypoint:
+  #     - /bin/bash
+  #   command:
+  #     - -c 
+  #     - | 
+  #         set -eu
+  #         sleep 10
+  #         exec ./hltv +connect 10.5.0.100:27015 -nomaster -nodns -port 27020
+
   # Uncomment to test CS2     
   # 1. Counter-Strike 2 gameserver sends HTTP logs to source-udp-forwarder
   # See: https://github.com/startersclan/docker-sourceservers

--- a/src/scripts/hlstats.pl
+++ b/src/scripts/hlstats.pl
@@ -1152,6 +1152,20 @@ sub getPlayerInfo
 				$name = "BOT-".$name;
 			}
 		}
+		# Uncomment this to consider HLTV as a bot
+		# elsif ($g_servers{$s_addr}->{play_game} == CSTRIKE()
+		# 		|| $g_servers{$s_addr}->{play_game} == TFC()
+		# 		|| $g_servers{$s_addr}->{play_game} == DOD()
+		# 		|| $g_servers{$s_addr}->{play_game} == NS()
+		# 		|| $g_servers{$s_addr}->{play_game} == VALVE()) {
+		# 	# For hlds - HLTV should be considered a bot
+		# 	# L 05/09/2025 - 17:41:44: "HLTV Proxy<5><HLTV><>" connected, address "10.5.0.4:27020"
+		# 	# L 05/09/2025 - 17:41:46: "HLTV Proxy<5><HLTV><>" entered the game
+		# 	# L 05/09/2025 - 17:41:46: "HLTV Proxy<5><HLTV><>" joined team "SPECTATOR"
+		# 	if ($uniqueid eq "HLTV") {
+		# 		$uniqueid = 'BOT';
+		# 	}
+		# }
 
 		if ($ipAddr eq "none") {
 			$ipAddr = "";

--- a/src/web/pages/livestats.php
+++ b/src/web/pages/livestats.php
@@ -227,7 +227,15 @@ function printserverstats($server_id)
             $thisteam = $teamdata[$curteam];
 			$teamcolor = 'background:'.$thisteam['playerlist_bgcolor'].';color:'.$thisteam['playerlist_color'];
 			$bordercolor = 'background:'.$thisteam['playerlist_bgcolor'].';color:'.$thisteam['playerlist_color'].';border-top:1px '.$thisteam['playerlist_color'].' solid';
-            $team_display_name = empty($thisteam['name']) ? "Unknown team" : htmlspecialchars($thisteam['name']);
+			$team_display_name  = $thisteam['name'] ? htmlspecialchars($thisteam['name']) : htmlspecialchars(ucfirst(strtolower($thisteam['name'])));
+			if ($team_display_name == '') {
+				// Team is not in hlstats_Teams, but is present in the game log, e.g. player<123><STEAM_0:0:xxxxxxx><SPECTATOR> and hence in Livestats table as (in cs1.6: SPECTATOR, UNASSIGNED) (in csgo: Spectator, Unassigned).
+				$team_display_name = $thisteam['team'] ? htmlspecialchars(ucfirst(strtolower($thisteam['team']))) : '';
+				// Team is not in hlstats_Teams, but is also empty in the game log, e.g. player<123><STEAM_0:0:xxxxxxx><> and hence is null in Livestats table. This is a connecting client 100% of the time.
+				if ($team_display_name == '') {
+					$team_display_name = 'Unknown team';
+				}
+			}
 
 			while (isset($playerdata[$curteam][$j]))
 			{


### PR DESCRIPTION
Fixes #88

Credits: @fred0r