### PR TITLE
Fix (web/config): Fix `DB_PCONNECT=1` not working in newer PHP versions

### DIFF
--- a/src/web/includes/class_db.php
+++ b/src/web/includes/class_db.php
@@ -82,7 +82,13 @@ class DB_mysql
 
 		if ( $use_pconnect )
 		{
-			$this->link = @mysqli_pconnect($db_addr, $db_user, $db_pass);
+			if (function_exists('mysqli_pconnect')) {
+				# Deprecated function
+				$this->link = @mysqli_pconnect($db_addr, $db_user, $db_pass);
+			} else {
+				# See: https://www.php.net/manual/en/mysqli.construct.php
+				$this->link = @mysqli_connect("p:$db_addr", $db_user, $db_pass);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Fixes #90

Credits: @fred0r
