### PR TITLE
unauthed users cant view chat

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,21 @@ services:
           set -eu
           exec hlds_linux -console -noipx -secure -game cstrike +map de_dust2 +maxplayers 32 +sv_lan 0 +ip 0.0.0.0 +port 27015 +rcon_password password +log on +logaddress_add 10.5.0.50 27500 +sv_visiblemaxplayers 30
 
+  # 1b. Uncomment to enable HLTV for CS1.6
+  # hltv:
+  #   image: goldsourceservers/cstrike:latest
+  #   ports:
+  #     - 27020:27020/udp
+  #   stop_signal: SIGKILL
+  #   entrypoint:
+  #     - /bin/bash
+  #   command:
+  #     - -c 
+  #     - | 
+  #         set -eu
+  #         sleep 10
+  #         exec ./hltv +connect 10.5.0.100:27015 -nomaster -nodns -port 27020
+
   # Uncomment to test CS2     
   # 1. Counter-Strike 2 gameserver sends HTTP logs to source-udp-forwarder
   # See: https://github.com/startersclan/docker-sourceservers

--- a/src/scripts/hlstats.pl
+++ b/src/scripts/hlstats.pl
@@ -1152,6 +1152,20 @@ sub getPlayerInfo
 				$name = "BOT-".$name;
 			}
 		}
+		# Uncomment this to consider HLTV as a bot
+		# elsif ($g_servers{$s_addr}->{play_game} == CSTRIKE()
+		# 		|| $g_servers{$s_addr}->{play_game} == TFC()
+		# 		|| $g_servers{$s_addr}->{play_game} == DOD()
+		# 		|| $g_servers{$s_addr}->{play_game} == NS()
+		# 		|| $g_servers{$s_addr}->{play_game} == VALVE()) {
+		# 	# For hlds - HLTV should be considered a bot
+		# 	# L 05/09/2025 - 17:41:44: "HLTV Proxy<5><HLTV><>" connected, address "10.5.0.4:27020"
+		# 	# L 05/09/2025 - 17:41:46: "HLTV Proxy<5><HLTV><>" entered the game
+		# 	# L 05/09/2025 - 17:41:46: "HLTV Proxy<5><HLTV><>" joined team "SPECTATOR"
+		# 	if ($uniqueid eq "HLTV") {
+		# 		$uniqueid = 'BOT';
+		# 	}
+		# }
 
 		if ($ipAddr eq "none") {
 			$ipAddr = "";

--- a/src/web/pages/chat.php
+++ b/src/web/pages/chat.php
@@ -36,6 +36,194 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 For support and installation notes visit http://www.hlxcommunity.com
 */
 
+class Auth
+{
+	var $ok = false;
+	var $error = false;
+
+	var $username, $password, $savepass;
+	var $sessionStart, $session;
+
+	var $userdata = array();
+
+	function __construct()
+	{
+		//@session_start();
+
+		if (valid_request($_POST['authusername'], false))
+		{
+			$this->username = valid_request($_POST['authusername'], false);
+			$this->password = valid_request($_POST['authpassword'], false);
+			$this->savepass = valid_request($_POST['authsavepass'], false);
+			$this->sessionStart = 0;
+
+			# clear POST vars so as not to confuse the receiving page
+			unset($_POST);
+			$_POST = array();
+
+			$this->session = false;
+
+			if($this->checkPass()==true)
+			{
+				// if we have success, save it in this users SESSION
+				$_SESSION['username']=$this->username;
+				$_SESSION['password']=$this->password;
+				$_SESSION['authsessionStart']=time();
+				$_SESSION['acclevel'] = $this->userdata['acclevel'];
+			}
+		}
+		elseif (isset($_SESSION['loggedin']))
+		{
+			$this->username = $_SESSION['username'];
+			$this->password = $_SESSION['password'];
+			$this->savepass = 0;
+			$this->sessionStart = $_SESSION['authsessionStart'];
+			$this->ok = true;
+			$this->error = false;
+			$this->session = true;
+			
+			if(!$this->checkPass())
+			{
+				unset($_SESSION['loggedin']);
+			}
+		}
+		else
+		{
+			$this->ok = false;
+			$this->error = false;
+
+			$this->session = false;
+
+			$this->printAuth();
+		}
+	}
+
+	function checkPass()
+	{
+		global $db;
+
+		$db->query("
+				SELECT
+					*
+				FROM
+					hlstats_Users
+				WHERE
+					username='$this->username'
+				LIMIT 1
+			");
+
+		if ($db->num_rows() == 1)
+		{
+			// The username is OK
+
+			$this->userdata = $db->fetch_array();
+			$db->free_result();
+
+			if (md5($this->password) == $this->userdata["password"])
+			{
+				// The username and the password are OK
+
+				$this->ok = true;
+				$this->error = false;
+				$_SESSION['loggedin']=1;
+				if ($this->sessionStart > (time() - 3600))
+				{
+					// Valid session, update session time & display the page
+					$this->doCookies();
+					return true;
+				}
+				elseif ($this->sessionStart)
+				{
+					// A session exists but has expired
+					if ($this->savepass)
+					{
+						// They selected 'Save my password' so we just
+						// generate a new session and show the page.
+						$this->doCookies();
+						return true;
+					}
+					else
+					{
+						$this->ok = false;
+						$this->error = 'Your session has expired. Please try again.';
+						$this->password = '';
+
+						$this->printAuth();
+						return false;
+					}
+				}
+				elseif (!$this->session)
+				{
+					// No session and no cookies, but the user/pass was
+					// POSTed, so we generate cookies.
+					$this->doCookies();
+					return true;
+				}
+				else
+				{
+					// No session, user/pass from a cookie, so we force auth
+					$this->printAuth();
+					return false;
+				}
+			}
+			else
+			{
+				// The username is OK but the password is wrong
+
+				$this->ok = false;
+				if ($this->session)
+				{
+					// Cookie without 'Save my password' - not an error
+					$this->error = false;
+				}
+				else
+				{
+					$this->error = 'The password you supplied is incorrect.';
+				}
+				$this->password = '';
+				$this->printAuth();
+			}
+		}
+		else
+		{
+			// The username is wrong
+			$this->ok = false;
+			$this->error = 'The username you supplied is not valid.';
+			$this->printAuth();
+		}
+	}
+
+	function doCookies()
+	{
+		return;
+		setcookie('authusername', $this->username, time() + 31536000, '', '', 0);
+
+		if ($this->savepass)
+		{
+			setcookie('authpassword', $this->password, time() + 31536000, '', '', 0);
+		}
+		else
+		{
+			setcookie('authpassword', $this->password, 0, '', '', 0);
+		}
+		setcookie('authsavepass', $this->savepass, time() + 31536000, '', '', 0);
+		setcookie('authsessionStart', time(), 0, '', '', 0);
+	}
+
+	function printAuth()
+	{
+		global $g_options;
+
+		include (PAGE_PATH . '/adminauth.php');
+	}
+}
+
+	$auth = new Auth;
+	if ($auth->ok === false || $auth->userdata['acclevel'] < 80)
+	{
+		return;
+	}
+
     if (!defined('IN_HLSTATS')) {
         die('Do not access this file directly.');
     }

--- a/src/web/pages/livestats.php
+++ b/src/web/pages/livestats.php
@@ -227,7 +227,15 @@ function printserverstats($server_id)
             $thisteam = $teamdata[$curteam];
 			$teamcolor = 'background:'.$thisteam['playerlist_bgcolor'].';color:'.$thisteam['playerlist_color'];
 			$bordercolor = 'background:'.$thisteam['playerlist_bgcolor'].';color:'.$thisteam['playerlist_color'].';border-top:1px '.$thisteam['playerlist_color'].' solid';
-            $team_display_name = empty($thisteam['name']) ? "Unknown team" : htmlspecialchars($thisteam['name']);
+			$team_display_name  = $thisteam['name'] ? htmlspecialchars($thisteam['name']) : htmlspecialchars(ucfirst(strtolower($thisteam['name'])));
+			if ($team_display_name == '') {
+				// Team is not in hlstats_Teams, but is present in the game log, e.g. player<123><STEAM_0:0:xxxxxxx><SPECTATOR> and hence in Livestats table as (in cs1.6: SPECTATOR, UNASSIGNED) (in csgo: Spectator, Unassigned).
+				$team_display_name = $thisteam['team'] ? htmlspecialchars(ucfirst(strtolower($thisteam['team']))) : '';
+				// Team is not in hlstats_Teams, but is also empty in the game log, e.g. player<123><STEAM_0:0:xxxxxxx><> and hence is null in Livestats table. This is a connecting client 100% of the time.
+				if ($team_display_name == '') {
+					$team_display_name = 'Unknown team';
+				}
+			}
 
 			while (isset($playerdata[$curteam][$j]))
 			{


### PR DESCRIPTION
viewing the serverchat-page needs account.
when removing  the chat-link and server is configured to log, the chats are still viewable by entering the concrete url.

https://github.com/startersclan/hlstatsx-community-edition/issues/75#issuecomment-2832301136