### PR TITLE
Fix (amxx-cstrike): rly fix rcon chat color3 not working

### DIFF
--- a/src/amxmodx/scripting/hlstatsx_commands_cstrike.sma
+++ b/src/amxmodx/scripting/hlstatsx_commands_cstrike.sma
@@ -968,7 +968,7 @@ public hlx_amx_hint(id, level, cid)
 		}
 		
 		if ((player_index > 0) && (!is_user_bot(player_index)) && (is_user_connected(player_index))) {
-			new color3[] = {255, 128, 0}
+			new color3[3] = {255, 128, 0}
 			new Float:verpos = 0.80
 	
 			set_hudmessage(color3[0], color3[1], color3[2], -1.0, verpos, 0, 6.0, 6.0, 0.5, 0.15, -1)


### PR DESCRIPTION
https://github.com/startersclan/hlstatsx-community-edition/pull/104 doesnt seem to work

fix for: doesnt compile: https://github.com/startersclan/hlstatsx-community-edition/pull/104#issuecomment-2874336326

_Originally posted in https://github.com/startersclan/hlstatsx-community-edition/discussions/99#discussioncomment-13125943_